### PR TITLE
Lexer for expansions

### DIFF
--- a/env.go
+++ b/env.go
@@ -1,0 +1,49 @@
+package interpolate
+
+import (
+	"runtime"
+	"strings"
+)
+
+type Env interface {
+	Get(key string) (string, bool)
+}
+
+// Creates an Env from a slice of environment variables
+func NewSliceEnv(env []string) Env {
+	envMap := mapEnv{}
+	for _, l := range env {
+		parts := strings.SplitN(l, "=", 2)
+		if len(parts) == 2 {
+			envMap[normalizeKeyName(parts[0])] = parts[1]
+		}
+	}
+	return envMap
+}
+
+// Creates an Env from a map of environment variables
+func NewMapEnv(env map[string]string) Env {
+	envMap := mapEnv{}
+	for k, v := range env {
+		envMap[normalizeKeyName(k)] = v
+	}
+	return envMap
+}
+
+type mapEnv map[string]string
+
+func (m mapEnv) Get(key string) (string, bool) {
+	if m == nil {
+		return "", false
+	}
+	val, ok := m[normalizeKeyName(key)]
+	return val, ok
+}
+
+// Windows isn't case sensitive for env
+func normalizeKeyName(key string) string {
+	if runtime.GOOS == "windows" {
+		return strings.ToUpper(key)
+	}
+	return key
+}

--- a/interpolate.go
+++ b/interpolate.go
@@ -1,227 +1,172 @@
 package interpolate
 
 import (
+	"bytes"
 	"fmt"
-	"regexp"
-	"runtime"
-	"strconv"
-	"strings"
-)
-
-var (
-	variablesWithBracketsRegex   = regexp.MustCompile(`([\\\$]?\$\{([^}]+?)})`)
-	variablesWithNoBracketsRegex = regexp.MustCompile(`([\\\$]?\$[a-zA-Z0-9_]+)`)
-	substringRegexp              = regexp.MustCompile(`\A\s*:\s*(\-?\s*\d+)(?:\s*:\s*(\-?\s*\d+))?\s*\z`)
 )
 
 // Interpolate takes a set of environment and interpolates it into the provided string using shell script expansions
-func Interpolate(env map[string]string, str string) (string, error) {
-	var err error
-
-	// Do a parse and handle ENV variables with the ${} syntax, i.e. ${FOO}
-	interpolated := variablesWithBracketsRegex.ReplaceAllStringFunc(str, func(v string) string {
-		// if there has been an error previously, skip interpolation
-		if err != nil {
-			return v
-		}
-		key, option := extractKeyAndOptionFromVariable(v)
-
-		// Just return the key by itself if it was escaped
-		if isPrefixedWithEscapeSequence(v) {
-			return key
-		}
-
-		err = isValidPosixEnvironmentVariable(v)
-		if err != nil {
-			return v
-		}
-
-		vv, isEnvironmentVariableSet := env[key]
-
-		switch {
-		case substringRegexp.MatchString(option):
-			// Substring Expansion -- select a substring of a variable with:
-			//
-			// ${parameter:offset}
-			// ${parameter:offset:length}
-			//
-			// In the first form select a substring of $parameter starting from
-			// 0-indexed offset until the end of $parameter. If offset is
-			// negative then it is an offset from the end of $parameter instead.
-			//
-			// In the second form, length is the number of characters from offset
-			// to select. If negeative, length is instead an offset from the end
-			// of $parameter.
-			//
-			match := substringRegexp.FindStringSubmatch(option)
-			lenvv := int64(len(vv))
-
-			offset, parseErr := strconv.ParseInt(match[1], 10, 0)
-			if err != nil {
-				err = parseErr
-				return v
-			}
-
-			// Negative offsets = from end
-			if offset < 0 {
-				offset = lenvv - (-offset)
-			}
-
-			// Still negative = too far from end? Truncate to start.
-			if offset < 0 {
-				offset = 0
-			}
-
-			// Beyond end? Truncate to end.
-			if offset > lenvv {
-				offset = lenvv
-			}
-
-			// Length?
-			if len(match) < 3 || match[2] == "" {
-				vv = vv[offset:lenvv]
-			} else {
-				length, parseErr := strconv.ParseInt(match[2], 10, 0)
-				if err != nil {
-					err = parseErr
-					return v
-				}
-
-				if length >= 0 {
-					// Positive length = from offset
-					length = offset + length
-
-					// Too far? Truncate to end.
-					if length > lenvv {
-						length = lenvv
-					}
-				} else {
-					// Negative length = from end
-					length = lenvv - (-length)
-
-					// Too far? Truncate to offset.
-					if length < offset {
-						length = offset
-					}
-				}
-
-				vv = vv[offset:length]
-			}
-
-		case strings.HasPrefix(option, "?"):
-			if vv == "" {
-				errorMessage := option[1:]
-				if errorMessage == "" {
-					errorMessage = "not set"
-				}
-				err = fmt.Errorf("$%s: %s", key, errorMessage)
-			}
-
-		case strings.HasPrefix(option, ":-"):
-			if vv == "" {
-				vv = option[2:]
-			}
-
-		case strings.HasPrefix(option, "-"):
-			if !isEnvironmentVariableSet {
-				vv = option[1:]
-			}
-
-		case option != "":
-			err = fmt.Errorf("Invalid option `%s` for environment variable `%s`", option, key)
-		}
-
-		return vv
-	})
+func Interpolate(env Env, str string) (string, error) {
+	if env == nil {
+		env = NewSliceEnv(nil)
+	}
+	expr, err := NewParser(str).Parse()
 	if err != nil {
-		return str, err
+		return "", err
+	}
+	return expr.Expand(env)
+}
+
+// An expansion is something that takes in ENV and returns a string or an error
+type Expansion interface {
+	Expand(env Env) (string, error)
+}
+
+// VariableExpansion represents either $VAR or ${VAR}, our simplest expansion
+type VariableExpansion struct {
+	Identifier string
+}
+
+func (e VariableExpansion) Expand(env Env) (string, error) {
+	val, _ := env.Get(e.Identifier)
+	return val, nil
+}
+
+// EmptyValueExpansion returns either the value of an env, or a default value if it's unset or null
+type EmptyValueExpansion struct {
+	Identifier string
+	Content    Expression
+}
+
+func (e EmptyValueExpansion) Expand(env Env) (string, error) {
+	val, _ := env.Get(e.Identifier)
+	if val == "" {
+		return e.Content.Expand(env)
+	}
+	return val, nil
+}
+
+// UnsetValueExpansion returns either the value of an env, or a default value if it's unset
+type UnsetValueExpansion struct {
+	Identifier string
+	Content    Expression
+}
+
+func (e UnsetValueExpansion) Expand(env Env) (string, error) {
+	val, ok := env.Get(e.Identifier)
+	if !ok {
+		return e.Content.Expand(env)
+	}
+	return val, nil
+}
+
+// SubstringExpansion returns a substring (or slice) of the env
+type SubstringExpansion struct {
+	Identifier string
+	Offset     int
+	Length     int
+	HasLength  bool
+}
+
+func (e SubstringExpansion) Expand(env Env) (string, error) {
+	val, _ := env.Get(e.Identifier)
+
+	from := e.Offset
+
+	// Negative offsets = from end
+	if from < 0 {
+		from += len(val)
 	}
 
-	// Another parse but this time target ENV variables without the {}
-	// surrounding it, i.e. $FOO. These ones are super simple to replace.
-	interpolated = variablesWithNoBracketsRegex.ReplaceAllStringFunc(interpolated, func(v string) string {
-		// if there has been an error previously, skip interpolation
-		if err != nil {
-			return v
-		}
-		key, _ := extractKeyAndOptionFromVariable(v)
+	// Still negative = too far from end? Truncate to start.
+	if from < 0 {
+		from = 0
+	}
 
-		// Just return the key by itself if it was escaped
-		if isPrefixedWithEscapeSequence(v) {
-			return key
-		}
+	// Beyond end? Truncate to end.
+	if from > len(val) {
+		from = len(val)
+	}
 
-		err = isValidPosixEnvironmentVariable(v)
-		if err != nil {
-			return v
-		}
+	if !e.HasLength {
+		return val[from:], nil
+	}
 
-		val, _ := env[key]
-		return val
-	})
+	to := e.Length
 
-	return interpolated, err
-}
-
-func isPrefixedWithEscapeSequence(variable string) bool {
-	return strings.HasPrefix(variable, "$$") || strings.HasPrefix(variable, "\\$")
-}
-
-var validPosixEnvironmentVariablePrefixRegex = regexp.MustCompile(`\A\${1}\{?[a-zA-Z]`)
-
-// Returns true if the variable is a valid POSIX environment variale. It will
-// return false if the variable begins with a number, or it starts with two $$
-// characters.
-func isValidPosixEnvironmentVariable(variable string) error {
-	if validPosixEnvironmentVariablePrefixRegex.MatchString(variable) {
-		return nil
+	if to >= 0 {
+		// Positive length = from offset
+		to += from
 	} else {
-		return fmt.Errorf("Invalid environment variable `%s` - they can only start with a letter", variable)
+		// Negative length = from end
+		to += len(val)
+
+		// Too far? Truncate to offset.
+		if to < from {
+			to = from
+		}
 	}
+
+	// Beyond end? Truncate to end.
+	if to > len(val) {
+		to = len(val)
+	}
+
+	return val[from:to], nil
 }
 
-var firstNonEnvironmentVariableCharacterRegex = regexp.MustCompile(`[^a-zA-Z0-9_]`)
+// RequiredExpansion returns an env value, or an error if it is unset
+type RequiredExpansion struct {
+	Identifier string
+	Message    Expression
+}
 
-// Takes an environment variable, and extracts the variable name and a suffixed
-// option.  For example, ${BEST_COMMAND:-lol} will be turned split into
-// "BEST_COMMAND" and ":-lol". Regualr environment variables like $FOO will
-// return "FOO" as the `key`, and a blank string as the `option`.
-func extractKeyAndOptionFromVariable(variable string) (key string, option string) {
-	if strings.HasPrefix(variable, "${") {
-		// Trim the first 2 characters `${` and the last character `}`
-		trimmed := variable[2 : len(variable)-1]
+func (e RequiredExpansion) Expand(env Env) (string, error) {
+	val, ok := env.Get(e.Identifier)
+	if !ok {
+		msg, err := e.Message.Expand(env)
+		if err != nil {
+			return "", err
+		}
+		if msg == "" {
+			msg = "not set"
+		}
+		return "", fmt.Errorf("$%s: %s", e.Identifier, msg)
+	}
+	return val, nil
+}
 
-		optionsIndicies := firstNonEnvironmentVariableCharacterRegex.FindStringIndex(trimmed)
-		if len(optionsIndicies) > 0 {
-			key = trimmed[0:optionsIndicies[0]]
-			option = trimmed[optionsIndicies[0]:]
+// Expression is a collection of either Text or Expansions
+type Expression []ExpressionItem
+
+func (e Expression) Expand(env Env) (string, error) {
+	buf := &bytes.Buffer{}
+
+	for _, item := range e {
+		if item.Expansion != nil {
+			result, err := item.Expansion.Expand(env)
+			if err != nil {
+				return "", err
+			}
+			_, _ = buf.WriteString(result)
 		} else {
-			key = trimmed
-		}
-	} else {
-		// Trim the first character `$`
-		key = variable[1:]
-	}
-
-	return
-}
-
-// Windows isn't case sensitive for env
-func normalizeKeyName(key string) string {
-	if runtime.GOOS == "windows" {
-		return strings.ToUpper(key)
-	}
-	return key
-}
-
-// Converts an env slice (like from os.Environ) to a map, with keys normalized to uppercase in windows
-func EnvFromSlice(env []string) map[string]string {
-	envMap := map[string]string{}
-	for _, l := range env {
-		parts := strings.SplitN(l, "=", 2)
-		if len(parts) == 2 {
-			envMap[normalizeKeyName(parts[0])] = parts[1]
+			_, _ = buf.WriteString(item.Text)
 		}
 	}
-	return envMap
+
+	return buf.String(), nil
+}
+
+// ExpressionItem models either an Expansion or Text. Either/Or, never both.
+type ExpressionItem struct {
+	Text string
+	// -- or --
+	Expansion Expansion
+}
+
+func (i ExpressionItem) String() string {
+	if i.Expansion != nil {
+		return fmt.Sprintf("%#v", i.Expansion)
+	}
+	return fmt.Sprintf("%q", i.Text)
 }

--- a/parser.go
+++ b/parser.go
@@ -1,0 +1,296 @@
+package interpolate
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// This is a recursive descent parser for our grammar. Because it can contain nested expressions like
+// ${LLAMAS:-${ROCK:-true}} we can't use regular expressions. The simplest possible alternative is
+// a recursive parser like this. It parses a chunk and then calls a function to parse that further
+// and so on and so forth. It results n a tree of objects that represent the things we've parsed (an AST).
+// This means that the logic for how expansions work lives in those objects, and the logic for how we go
+// from plain text to parsed objects lives here.
+//
+// To keep things simple, we do our "lexing" or "scanning" just as a few functions at the end of the file
+// rather than as a dedicated lexer that emits tokens. This matches the simplicity of the format we are parsing
+// relatively well
+//
+// Below is an EBNF grammar for the language. The oarser was built by basically turning this into functions
+// and structs named the same reading the string bite by bite (peekRune and nextRune)
+
+/*
+EscapedBackslash = "\\"
+EscapedDollar    = ( "\$" | "$$")
+Identifier       = letter { letters | digit | "_" }
+Expansion        = "$" ( Identifier | Brace )
+Brace            = "{" Identifier [ Identifier BraceOperation ] "}"
+Text             = { EscapedBackslash | EscapedDollar | all characters except "$" }
+Expression       = { Text | Expansion }
+EmptyValue       = ":-" { Expression }
+UnsetValue       = "-" { Expression }
+Substring        = ":" number [ ":" number ]
+Required         = "?" { Expression }
+Operation        = EmptyValue | UnsetValue | Substring | Required
+*/
+
+const (
+	eof = -1
+)
+
+// Parser takes a string and parses out a tree of structs that represent text and Expansions
+type Parser struct {
+	input string // the string we are scanning
+	pos   int    // the current position
+}
+
+// NewParser returns a new instance of a Parser
+func NewParser(str string) *Parser {
+	return &Parser{
+		input: str,
+		pos:   0,
+	}
+}
+
+// Parse expansions out of the internal text and return them as a tree of Expressions
+func (p *Parser) Parse() (Expression, error) {
+	return p.parseExpression()
+}
+
+func (p *Parser) parseExpression(stop ...rune) (Expression, error) {
+	var expr Expression
+	var stopStr = string(stop)
+
+	for {
+		c := p.peekRune()
+		if c == eof || strings.ContainsRune(stopStr, c) {
+			break
+		}
+
+		// check for our escaped characters first, as we assume nothing subsequently is escaped
+		if strings.HasPrefix(p.input[p.pos:], `\\`) {
+			p.pos += 2
+			expr = append(expr, ExpressionItem{Text: `\\`})
+			continue
+		} else if strings.HasPrefix(p.input[p.pos:], `\$`) || strings.HasPrefix(p.input[p.pos:], `$$`) {
+			p.pos += 2
+			expr = append(expr, ExpressionItem{Text: `$`})
+			continue
+		}
+
+		// If we run into a dollar sign, it's an expansion
+		if c == '$' {
+			expansion, err := p.parseExpansion()
+			if err != nil {
+				return nil, err
+			}
+			expr = append(expr, ExpressionItem{Expansion: expansion})
+			continue
+		}
+
+		// Otherwise, we can scan as much as we can into text
+		text := p.scanUntil(func(r rune) bool {
+			return (r == '$' || r == '\\' || strings.ContainsRune(stopStr, r))
+		})
+
+		expr = append(expr, ExpressionItem{Text: text})
+	}
+
+	return expr, nil
+}
+
+func (p *Parser) parseExpansion() (Expansion, error) {
+	if c := p.nextRune(); c != '$' {
+		return nil, fmt.Errorf("Expected expansion to start with $, got %c", c)
+	}
+
+	// if we have an open brace, this is a brace expansion
+	if c := p.peekRune(); c == '{' {
+		return p.parseBraceExpansion()
+	}
+
+	identifier, err := p.scanIdentifier()
+	if err != nil {
+		return nil, err
+	}
+
+	return VariableExpansion{Identifier: identifier}, nil
+}
+
+func (p *Parser) parseBraceExpansion() (Expansion, error) {
+	if c := p.nextRune(); c != '{' {
+		return nil, fmt.Errorf("Expected brace expansion to start with {, got %c", c)
+	}
+
+	identifier, err := p.scanIdentifier()
+	if err != nil {
+		return nil, err
+	}
+
+	if c := p.peekRune(); c == '}' {
+		_ = p.nextRune()
+		return VariableExpansion{Identifier: identifier}, nil
+	}
+
+	var operator string
+	var exp Expansion
+
+	// Parse an operator, some trickery is needed to handle : vs :-
+	if op1 := p.nextRune(); op1 == ':' {
+		if op2 := p.peekRune(); op2 == '-' {
+			_ = p.nextRune()
+			operator = ":-"
+		} else {
+			operator = ":"
+		}
+	} else if op1 == '?' || op1 == '-' {
+		operator = string(op1)
+	} else {
+		return nil, fmt.Errorf("Expected an operator, got %c", op1)
+	}
+
+	switch operator {
+	case `:-`:
+		exp, err = p.parseEmptyValueOrSubstringExpansion(identifier)
+		if err != nil {
+			return nil, err
+		}
+	case `-`:
+		exp, err = p.parseUnsetValueExpansion(identifier)
+		if err != nil {
+			return nil, err
+		}
+	case `:`:
+		exp, err = p.parseSubstringExpansion(identifier)
+		if err != nil {
+			return nil, err
+		}
+	case `?`:
+		exp, err = p.parseRequiredExpansion(identifier)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if c := p.nextRune(); c != '}' {
+		return nil, fmt.Errorf("Expected brace expansion to end with }, got %c", c)
+	}
+
+	return exp, nil
+}
+
+func (p *Parser) parseEmptyValueOrSubstringExpansion(identifier string) (Expansion, error) {
+	// as a special case, we need to return a substring operator for ${VAR:-1} and ${VAR:-1:5}
+	// this heuristic should be good enough, although it's possible we might need to parse out the entirety
+	if c := p.peekRune(); unicode.IsNumber(c) {
+		expr, err := p.parseSubstringExpansion(identifier)
+		if err != nil {
+			return nil, err
+		}
+
+		substr, ok := expr.(SubstringExpansion)
+		if !ok {
+			return nil, errors.New("Unable to convert to SubstringExpansion")
+		}
+
+		// we swallowed the negative sign, so correct for that
+		substr.Offset *= -1
+		return substr, err
+	}
+
+	// parse an expression (text and expansions) up until the end of the brace
+	expr, err := p.parseExpression('}')
+	if err != nil {
+		return nil, err
+	}
+
+	return EmptyValueExpansion{Identifier: identifier, Content: expr}, nil
+}
+
+func (p *Parser) parseUnsetValueExpansion(identifier string) (Expansion, error) {
+	expr, err := p.parseExpression('}')
+	if err != nil {
+		return nil, err
+	}
+
+	return UnsetValueExpansion{Identifier: identifier, Content: expr}, nil
+}
+
+func (p *Parser) parseSubstringExpansion(identifier string) (Expansion, error) {
+	offset := p.scanUntil(func(r rune) bool {
+		return r == ':' || r == '}'
+	})
+
+	offsetInt, err := strconv.Atoi(strings.TrimSpace(offset))
+	if err != nil {
+		return nil, fmt.Errorf("Unable to parse offset: %v", err)
+	}
+
+	if c := p.peekRune(); c == '}' {
+		return SubstringExpansion{Identifier: identifier, Offset: offsetInt}, nil
+	}
+
+	_ = p.nextRune()
+	length := p.scanUntil(func(r rune) bool {
+		return r == '}'
+	})
+
+	lengthInt, err := strconv.Atoi(strings.TrimSpace(length))
+	if err != nil {
+		return nil, fmt.Errorf("Unable to parse length: %v", err)
+	}
+
+	return SubstringExpansion{Identifier: identifier, Offset: offsetInt, Length: lengthInt, HasLength: true}, nil
+}
+
+func (p *Parser) parseRequiredExpansion(identifier string) (Expansion, error) {
+	expr, err := p.parseExpression('}')
+	if err != nil {
+		return nil, err
+	}
+
+	return RequiredExpansion{Identifier: identifier, Message: expr}, nil
+}
+
+func (p *Parser) scanUntil(f func(rune) bool) string {
+	start := p.pos
+	for int(p.pos) < len(p.input) {
+		c, size := utf8.DecodeRuneInString(p.input[p.pos:])
+		if f(c) {
+			break
+		}
+		p.pos += size
+	}
+	return p.input[start:p.pos]
+}
+
+func (p *Parser) scanIdentifier() (string, error) {
+	if c := p.peekRune(); !unicode.IsLetter(c) {
+		return "", errors.New("Expected identifier to start with a letter")
+	}
+	var notIdentifierChar = func(r rune) bool {
+		return (!unicode.IsLetter(r) && !unicode.IsNumber(r) && r != '_')
+	}
+	return p.scanUntil(notIdentifierChar), nil
+}
+
+func (p *Parser) nextRune() rune {
+	if int(p.pos) >= len(p.input) {
+		return eof
+	}
+	c, size := utf8.DecodeRuneInString(p.input[p.pos:])
+	p.pos += size
+	return c
+}
+
+func (p *Parser) peekRune() rune {
+	if int(p.pos) >= len(p.input) {
+		return eof
+	}
+	c, _ := utf8.DecodeRuneInString(p.input[p.pos:])
+	return c
+}

--- a/parser.go
+++ b/parser.go
@@ -12,7 +12,7 @@ import (
 // This is a recursive descent parser for our grammar. Because it can contain nested expressions like
 // ${LLAMAS:-${ROCK:-true}} we can't use regular expressions. The simplest possible alternative is
 // a recursive parser like this. It parses a chunk and then calls a function to parse that further
-// and so on and so forth. It results n a tree of objects that represent the things we've parsed (an AST).
+// and so on and so forth. It results in a tree of objects that represent the things we've parsed (an AST).
 // This means that the logic for how expansions work lives in those objects, and the logic for how we go
 // from plain text to parsed objects lives here.
 //
@@ -20,7 +20,7 @@ import (
 // rather than as a dedicated lexer that emits tokens. This matches the simplicity of the format we are parsing
 // relatively well
 //
-// Below is an EBNF grammar for the language. The oarser was built by basically turning this into functions
+// Below is an EBNF grammar for the language. The parser was built by basically turning this into functions
 // and structs named the same reading the string bite by bite (peekRune and nextRune)
 
 /*

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,0 +1,164 @@
+package interpolate_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/buildkite/interpolate"
+)
+
+func TestParser(t *testing.T) {
+	var testCases = []struct {
+		String   string
+		Expected []interpolate.ExpressionItem
+	}{
+		{
+			String: `Buildkite... ${HELLO_WORLD} ${ANOTHER_VAR:-🏖}`,
+			Expected: []interpolate.ExpressionItem{
+				{Text: "Buildkite... "},
+				{Expansion: interpolate.VariableExpansion{
+					Identifier: "HELLO_WORLD",
+				}},
+				{Text: " "},
+				{Expansion: interpolate.EmptyValueExpansion{
+					Identifier: "ANOTHER_VAR",
+					Content: interpolate.Expression([]interpolate.ExpressionItem{{
+						Text: "🏖",
+					}}),
+				}},
+			},
+		},
+		{
+			String: `${TEST1:- ${TEST2:-$TEST3}}`,
+			Expected: []interpolate.ExpressionItem{
+				{Expansion: interpolate.EmptyValueExpansion{
+					Identifier: "TEST1",
+					Content: interpolate.Expression([]interpolate.ExpressionItem{
+						{Text: " "},
+						{Expansion: interpolate.EmptyValueExpansion{
+							Identifier: "TEST2",
+							Content: interpolate.Expression([]interpolate.ExpressionItem{
+								{Expansion: interpolate.VariableExpansion{
+									Identifier: "TEST3",
+								}},
+							}),
+						}},
+					}),
+				}},
+			},
+		},
+		{
+			String: `${HELLO_WORLD-blah}`,
+			Expected: []interpolate.ExpressionItem{
+				{Expansion: interpolate.UnsetValueExpansion{
+					Identifier: "HELLO_WORLD",
+					Content: interpolate.Expression([]interpolate.ExpressionItem{{
+						Text: "blah",
+					}}),
+				}},
+			},
+		},
+		{
+			String: `\\${HELLO_WORLD-blah}`,
+			Expected: []interpolate.ExpressionItem{
+				{Text: `\\`},
+				{Expansion: interpolate.UnsetValueExpansion{
+					Identifier: "HELLO_WORLD",
+					Content: interpolate.Expression([]interpolate.ExpressionItem{{
+						Text: "blah",
+					}}),
+				}},
+			},
+		},
+		{
+			String: `\${HELLO_WORLD-blah}`,
+			Expected: []interpolate.ExpressionItem{
+				{Text: `$`},
+				{Text: `{HELLO_WORLD-blah}`},
+			},
+		},
+		{
+			String: `Test \\\${HELLO_WORLD-blah}`,
+			Expected: []interpolate.ExpressionItem{
+				{Text: `Test `},
+				{Text: `\\`},
+				{Text: `$`},
+				{Text: `{HELLO_WORLD-blah}`},
+			},
+		},
+		{
+			String: `${HELLO_WORLD:1}`,
+			Expected: []interpolate.ExpressionItem{
+				{Expansion: interpolate.SubstringExpansion{
+					Identifier: "HELLO_WORLD",
+					Offset:     1,
+				}},
+			},
+		},
+		{
+			String: `${HELLO_WORLD: -1}`,
+			Expected: []interpolate.ExpressionItem{
+				{Expansion: interpolate.SubstringExpansion{
+					Identifier: "HELLO_WORLD",
+					Offset:     -1,
+				}},
+			},
+		},
+		{
+			String: `${HELLO_WORLD:-1}`,
+			Expected: []interpolate.ExpressionItem{
+				{Expansion: interpolate.SubstringExpansion{
+					Identifier: "HELLO_WORLD",
+					Offset:     -1,
+				}},
+			},
+		},
+		{
+			String: `${HELLO_WORLD:1:7}`,
+			Expected: []interpolate.ExpressionItem{
+				{Expansion: interpolate.SubstringExpansion{
+					Identifier: "HELLO_WORLD",
+					Offset:     1,
+					Length:     7,
+					HasLength:  true,
+				}},
+			},
+		},
+		{
+			String: `${HELLO_WORLD:1:-7}`,
+			Expected: []interpolate.ExpressionItem{
+				{Expansion: interpolate.SubstringExpansion{
+					Identifier: "HELLO_WORLD",
+					Offset:     1,
+					Length:     -7,
+					HasLength:  true,
+				}},
+			},
+		},
+		{
+			String: `${HELLO_WORLD?Required}`,
+			Expected: []interpolate.ExpressionItem{
+				{Expansion: interpolate.RequiredExpansion{
+					Identifier: "HELLO_WORLD",
+					Message: interpolate.Expression([]interpolate.ExpressionItem{
+						{Text: "Required"},
+					}),
+				}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.String, func(t *testing.T) {
+			actual, err := interpolate.NewParser(tc.String).Parse()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			expected := interpolate.Expression(tc.Expected)
+			if !reflect.DeepEqual(expected, actual) {
+				t.Fatalf("Expected vs Actual: \n%s\n\n%s", expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Replace the regular expression based parsing with a recursive descent parser / lexer. This lets us parse nested variable expansions like `${VAR:-${BLAH:-1}}` and also it avoids the bug we discovered where the current interpolator runs in two passes and can resolve variables more times than expected. 