### PR TITLE
Add Identifiers() for parsing identifiers from expansions

### DIFF
--- a/interpolate.go
+++ b/interpolate.go
@@ -17,14 +17,28 @@ func Interpolate(env Env, str string) (string, error) {
 	return expr.Expand(env)
 }
 
+// Indentifiers parses the identifiers from any expansions in the provided string
+func Identifiers(str string) ([]string, error) {
+	expr, err := NewParser(str).Parse()
+	if err != nil {
+		return nil, err
+	}
+	return expr.Identifiers(), nil
+}
+
 // An expansion is something that takes in ENV and returns a string or an error
 type Expansion interface {
 	Expand(env Env) (string, error)
+	Identifiers() []string
 }
 
 // VariableExpansion represents either $VAR or ${VAR}, our simplest expansion
 type VariableExpansion struct {
 	Identifier string
+}
+
+func (e VariableExpansion) Identifiers() []string {
+	return []string{e.Identifier}
 }
 
 func (e VariableExpansion) Expand(env Env) (string, error) {
@@ -36,6 +50,10 @@ func (e VariableExpansion) Expand(env Env) (string, error) {
 type EmptyValueExpansion struct {
 	Identifier string
 	Content    Expression
+}
+
+func (e EmptyValueExpansion) Identifiers() []string {
+	return append([]string{e.Identifier}, e.Content.Identifiers()...)
 }
 
 func (e EmptyValueExpansion) Expand(env Env) (string, error) {
@@ -52,6 +70,10 @@ type UnsetValueExpansion struct {
 	Content    Expression
 }
 
+func (e UnsetValueExpansion) Identifiers() []string {
+	return []string{e.Identifier}
+}
+
 func (e UnsetValueExpansion) Expand(env Env) (string, error) {
 	val, ok := env.Get(e.Identifier)
 	if !ok {
@@ -66,6 +88,10 @@ type SubstringExpansion struct {
 	Offset     int
 	Length     int
 	HasLength  bool
+}
+
+func (e SubstringExpansion) Identifiers() []string {
+	return []string{e.Identifier}
 }
 
 func (e SubstringExpansion) Expand(env Env) (string, error) {
@@ -121,6 +147,10 @@ type RequiredExpansion struct {
 	Message    Expression
 }
 
+func (e RequiredExpansion) Identifiers() []string {
+	return []string{e.Identifier}
+}
+
 func (e RequiredExpansion) Expand(env Env) (string, error) {
 	val, ok := env.Get(e.Identifier)
 	if !ok {
@@ -138,6 +168,16 @@ func (e RequiredExpansion) Expand(env Env) (string, error) {
 
 // Expression is a collection of either Text or Expansions
 type Expression []ExpressionItem
+
+func (e Expression) Identifiers() []string {
+	identifiers := []string{}
+	for _, item := range e {
+		if item.Expansion != nil {
+			identifiers = append(identifiers, item.Expansion.Identifiers()...)
+		}
+	}
+	return identifiers
+}
 
 func (e Expression) Expand(env Env) (string, error) {
 	buf := &bytes.Buffer{}

--- a/interpolate_test.go
+++ b/interpolate_test.go
@@ -3,6 +3,7 @@ package interpolate_test
 import (
 	"fmt"
 	"log"
+	"reflect"
 	"testing"
 
 	"github.com/buildkite/interpolate"
@@ -265,6 +266,25 @@ func TestEscapingVariables(t *testing.T) {
 		}
 		if result != tc.Expected {
 			t.Fatalf("Test %q failed: Expected substring %q, got %q", tc.Str, tc.Expected, result)
+		}
+	}
+}
+
+func TestExtractingIdentifiers(t *testing.T) {
+	for _, tc := range []struct {
+		Str         string
+		Identifiers []string
+	}{
+		{`Hello ${REQUIRED_VAR?}`, []string{`REQUIRED_VAR`}},
+		{`${LLAMAS:-${ROCK:-true}}`, []string{`LLAMAS`, `ROCK`}},
+		{`${BUILDKITE_COMMIT:0}`, []string{`BUILDKITE_COMMIT`}},
+	} {
+		id, err := interpolate.Identifiers(tc.Str)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(id, tc.Identifiers) {
+			t.Fatalf("Test %q should have identifiers %v, got %v", tc.Str, tc.Identifiers, id)
 		}
 	}
 }


### PR DESCRIPTION
This allows for extracting identifiers from expansion strings:

```go
ids, _ := interpolate.Identifiers("${LLAMAS:-${ROCK:-$ALWAYS}}")
# [`LLAMAS`,`ROCK`, `ALWAYS`]
```