### PR TITLE
Update substring parser to comply with Bash's rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Interpolate
 
 [![GoDoc](https://godoc.org/github.com/buildkite/interpolate?status.svg)](https://godoc.org/github.com/buildkite/interpolate)
 
-A golang library for parameter expansion (like `${BLAH}` or `$BLAH`) in strings from environment variables. An implementation of [POSIX Parameter Expansion](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_02), plus some other basic operations that you'd expect in a shell scripting environment like bash.
+A golang library for parameter expansion (like `${BLAH}` or `$BLAH`) in strings from environment variables. An implementation of [POSIX Parameter Expansion](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_02), plus some other basic operations that you'd expect in a shell scripting environment [like bash](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html).
 
 ## Installation
 
@@ -47,10 +47,10 @@ func main() {
   <dd><strong>Use default values when not set.</strong> If parameter is unset, the expansion of word (or an empty string if word is omitted) shall be substituted; otherwise, the value of parameter shall be substituted.</dd>
 
   <dt><code>${parameter:<em>[offset]</em>}</code></dt>
-  <dd><strong>Use the substring of parameter after offset.</strong> A negative number will select from the end of the string. If the value is out of bounds, an empty string will be substituted.</dd>
+  <dd><strong>Use the substring of parameter after offset.</strong> A negative offset must be separated from the colon with a space, and will select from the end of the string. If the value is out of bounds, an empty string will be substituted.</dd>
 
   <dt><code>${parameter:<em>[offset]</em>:<em>[length]</em>}</code></dt>
-  <dd><strong>Use the substring of parameter after offset of given length.</strong> A negative number will select from the end of the string. If the offset is out of bounds, an empty string will be substituted. If the length is greater than the length then the entire string will be returned.</dd>
+  <dd><strong>Use the substring of parameter after offset of given length.</strong> A negative offset must be separated from the colon with a space, and will select from the end of the string. If the offset is out of bounds, an empty string will be substituted. If the length is greater than the length then the entire string will be returned.</dd>
 
   <dt><code>${parameter:?<em>[word]</em>}</code></dt>
   <dd>Indicate Error if Null or Unset. If parameter is unset or null, the expansion of word (or a message indicating it is unset if word is omitted) shall be returned as an error.</dd>

--- a/interpolate_test.go
+++ b/interpolate_test.go
@@ -149,10 +149,10 @@ func TestSubstringsWithOffsets(t *testing.T) {
 		// in range offsets, no lengths
 		{`${BUILDKITE_COMMIT:0}`, `1adf998e39f647b4b25842f107c6ed9d30a3a7c7`},
 		{`${BUILDKITE_COMMIT:7}`, `e39f647b4b25842f107c6ed9d30a3a7c7`},
-		{`${BUILDKITE_COMMIT:-7}`, `0a3a7c7`},
+		{`${BUILDKITE_COMMIT: -7}`, `0a3a7c7`},
 
 		// out of range offsets, no lengths
-		{`${BUILDKITE_COMMIT:-128}`, `1adf998e39f647b4b25842f107c6ed9d30a3a7c7`},
+		{`${BUILDKITE_COMMIT: -128}`, `1adf998e39f647b4b25842f107c6ed9d30a3a7c7`},
 		{`${BUILDKITE_COMMIT:128}`, ``},
 
 		// in range offsets and lengths
@@ -223,6 +223,7 @@ func TestDefaultValues(t *testing.T) {
 		{`Today is ${EMPTY_DAY:-Wednesday}`, `Today is Wednesday`},
 		{`${EMPTY_DAY:--:{}}`, `-:{}`},
 		{`${EMPTY:-${LLAMAS-test}}`, `test`},
+		{`${EMPTY:-127}`, `127`},
 	} {
 		result, err := interpolate.Interpolate(environ, tc.Str)
 		if err != nil {

--- a/parser.go
+++ b/parser.go
@@ -1,7 +1,6 @@
 package interpolate
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -165,7 +164,7 @@ func (p *Parser) parseBraceExpansion() (Expansion, error) {
 
 	switch operator {
 	case `:-`:
-		exp, err = p.parseEmptyValueOrSubstringExpansion(identifier)
+		exp, err = p.parseEmptyValueExpansion(identifier)
 		if err != nil {
 			return nil, err
 		}
@@ -193,25 +192,7 @@ func (p *Parser) parseBraceExpansion() (Expansion, error) {
 	return exp, nil
 }
 
-func (p *Parser) parseEmptyValueOrSubstringExpansion(identifier string) (Expansion, error) {
-	// as a special case, we need to return a substring operator for ${VAR:-1} and ${VAR:-1:5}
-	// this heuristic should be good enough, although it's possible we might need to parse out the entirety
-	if c := p.peekRune(); unicode.IsNumber(c) {
-		expr, err := p.parseSubstringExpansion(identifier)
-		if err != nil {
-			return nil, err
-		}
-
-		substr, ok := expr.(SubstringExpansion)
-		if !ok {
-			return nil, errors.New("Unable to convert to SubstringExpansion")
-		}
-
-		// we swallowed the negative sign, so correct for that
-		substr.Offset *= -1
-		return substr, err
-	}
-
+func (p *Parser) parseEmptyValueExpansion(identifier string) (Expansion, error) {
 	// parse an expression (text and expansions) up until the end of the brace
 	expr, err := p.parseExpression('}')
 	if err != nil {

--- a/parser_test.go
+++ b/parser_test.go
@@ -107,9 +107,11 @@ func TestParser(t *testing.T) {
 		{
 			String: `${HELLO_WORLD:-1}`,
 			Expected: []interpolate.ExpressionItem{
-				{Expansion: interpolate.SubstringExpansion{
+				{Expansion: interpolate.EmptyValueExpansion{
 					Identifier: "HELLO_WORLD",
-					Offset:     -1,
+					Content: interpolate.Expression([]interpolate.ExpressionItem{{
+						Text: "1",
+					}}),
 				}},
 			},
 		},


### PR DESCRIPTION
The substring parser is a Bash extension to POSIX Parameter Expansion, and it turns out our parsing has been different from how Bash's works for a while now, causing the singular gotcha that it is impossible to substitute a numeric value in the default value expansion.

For example, this expansion: [`${EMPTY:-127}` works in Bash](https://repl.it/@ticky/RadiantHandmadeBrackets) and Zsh, giving you a result of `127` if `EMPTY` is unset, however, the same expansion is treated as a negative-offset substring expansion by interpolate, meaning you end up with a blank value rather than the expected default.

This seems to have been written this way intentionally, but it seems to be an oversight.

I've updated the parser to not special-case a numeric character following the :- operator, as the Bash-approved way is to require a space character after the - to disambiguate the two similar, but distinct functions. I’ve also updated the documentation to point that out, and all the tests to comply with this rule.