### PR TITLE
Include escaped interpolations in identifiers

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,26 @@
+steps:
+  - name: ":go::robot_face: Lint"
+    key: lint
+    command: .buildkite/steps/lint.sh
+    plugins:
+      - docker#v5.11.0:
+          image: "golang:1.22"
+
+  - name: ":go::test_tube: Test"
+    key: test
+    command: ".buildkite/steps/test.sh"
+    artifact_paths: junit-*.xml
+    plugins:
+      - docker#v5.11.0:
+          image: "golang:1.22"
+          propagate-environment: true
+      - artifacts#v1.9.0:
+          upload: "cover.{html,out}"
+
+  - label: ":writing_hand: Annotate with Test Failures"
+    key: annotate
+    depends_on: test
+    allow_dependency_failure: true
+    plugins:
+      - junit-annotate#v1.6.0:
+          artifacts: junit-*.xml

--- a/.buildkite/steps/lint.sh
+++ b/.buildkite/steps/lint.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -Eeufo pipefail
+
+echo --- :go: Checking go mod tidiness
+go mod tidy
+if ! git diff --no-ext-diff --exit-code; then
+  echo ^^^ +++
+  echo "The go.mod or go.sum files are out of sync with the source code"
+  echo "Please run \`go mod tidy\` locally, and commit the result."
+
+  exit 1
+fi
+
+echo --- :go: Checking go formatting
+gofmt -w .
+if ! git diff --no-ext-diff --exit-code; then
+  echo ^^^ +++
+  echo "Files have not been formatted with gofmt."
+  echo "Fix this by running \`go fmt ./...\` locally, and committing the result."
+
+  exit 1
+fi
+
+echo +++ Everything is clean and tidy! 🎉

--- a/.buildkite/steps/test.sh
+++ b/.buildkite/steps/test.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+go install gotest.tools/gotestsum@v1.8.0
+
+echo '+++ Running tests'
+gotestsum --junitfile "junit-${BUILDKITE_JOB_ID}.xml" -- -count=1 -coverprofile=cover.out -race "$@" ./...
+
+echo 'Producing coverage report'
+go tool cover -html cover.out -o cover.html

--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ func main() {
   <dd><strong>Use the substring of parameter after offset of given length.</strong> A negative offset must be separated from the colon with a space, and will select from the end of the string. If the offset is out of bounds, an empty string will be substituted. If the length is greater than the length then the entire string will be returned.</dd>
 
   <dt><code>${parameter:?<em>[word]</em>}</code></dt>
-  <dd>Indicate Error if Null or Unset. If parameter is unset or null, the expansion of word (or a message indicating it is unset if word is omitted) shall be returned as an error.</dd>
+  <dd><strong>Indicate Error if Null or Unset.</strong> If parameter is unset or null, the expansion of word (or a message indicating it is unset if word is omitted) shall be returned as an error.</dd>
+
+  <dt><code>$$parameter</code> or <code>\$parameter</code> or <code>$${expression}</code> or <code>\${expression}</code></dt>
+  <dd><strong>An escaped interpolation.</strong> Will not be interpolated, but will be unescaped by a call to <code>interpolate.Interpolate()</code></dd>
 </dl>
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Interpolate
 ===========
 
+[![Build status](https://badge.buildkite.com/3d9081230a965a20d7b68d66564644febdada7f968cc6f9c9c.svg)](https://buildkite.com/buildkite/interpolate)
 [![GoDoc](https://godoc.org/github.com/buildkite/interpolate?status.svg)](https://godoc.org/github.com/buildkite/interpolate)
 
 A golang library for parameter expansion (like `${BLAH}` or `$BLAH`) in strings from environment variables. An implementation of [POSIX Parameter Expansion](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_02), plus some other basic operations that you'd expect in a shell scripting environment [like bash](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html).

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/buildkite/interpolate
+
+go 1.22.3

--- a/interpolate.go
+++ b/interpolate.go
@@ -82,6 +82,19 @@ func (e UnsetValueExpansion) Expand(env Env) (string, error) {
 	return val, nil
 }
 
+// EscapedExpansion is an expansion that is delayed until later on (usually by a later process)
+type EscapedExpansion struct {
+	Identifier string
+}
+
+func (e EscapedExpansion) Identifiers() []string {
+	return []string{"$" + e.Identifier}
+}
+
+func (e EscapedExpansion) Expand(Env) (string, error) {
+	return "$" + e.Identifier, nil
+}
+
 // SubstringExpansion returns a substring (or slice) of the env
 type SubstringExpansion struct {
 	Identifier string

--- a/interpolate_test.go
+++ b/interpolate_test.go
@@ -24,6 +24,8 @@ func ExampleInterpolate() {
 }
 
 func TestBasicInterpolation(t *testing.T) {
+	t.Parallel()
+
 	environ := interpolate.NewMapEnv(map[string]string{
 		"TEST1": "A test",
 		"TEST2": "Another",
@@ -49,6 +51,8 @@ func TestBasicInterpolation(t *testing.T) {
 		{`${TEST4}`, "Only one level of $TEST3 interpolation"},
 	} {
 		t.Run(tc.Str, func(t *testing.T) {
+			t.Parallel()
+
 			result, err := interpolate.Interpolate(environ, tc.Str)
 			if err != nil {
 				t.Fatal(err)
@@ -61,6 +65,8 @@ func TestBasicInterpolation(t *testing.T) {
 }
 
 func TestNestedInterpolation(t *testing.T) {
+	t.Parallel()
+
 	environ := interpolate.NewMapEnv(map[string]string{
 		"TEST1": "A test",
 		"TEST2": "Another",
@@ -77,6 +83,8 @@ func TestNestedInterpolation(t *testing.T) {
 		{`${TEST5:-Some text ${TEST2:-$TEST1} with $TEST3}`, "Some text Another with Llamas"},
 	} {
 		t.Run(tc.Str, func(t *testing.T) {
+			t.Parallel()
+
 			result, err := interpolate.Interpolate(environ, tc.Str)
 			if err != nil {
 				t.Fatal(err)
@@ -89,6 +97,8 @@ func TestNestedInterpolation(t *testing.T) {
 }
 
 func TestIgnoresParentheses(t *testing.T) {
+	t.Parallel()
+
 	for _, str := range []string{
 		`$(echo hello world)`,
 		`testing $(echo hello world)`,
@@ -105,6 +115,8 @@ func TestIgnoresParentheses(t *testing.T) {
 }
 
 func TestVariablesMustStartWithLetters(t *testing.T) {
+	t.Parallel()
+
 	for _, str := range []string{
 		`$1 burgers`,
 		`$99bottles`,
@@ -119,6 +131,8 @@ func TestVariablesMustStartWithLetters(t *testing.T) {
 }
 
 func TestMissingParameterValuesReturnEmptyStrings(t *testing.T) {
+	t.Parallel()
+
 	for _, str := range []string{
 		`$BUILDKITE_COMMIT`,
 		`${BUILDKITE_COMMIT}`,
@@ -128,6 +142,8 @@ func TestMissingParameterValuesReturnEmptyStrings(t *testing.T) {
 		`${BUILDKITE_COMMIT:7:14}`,
 	} {
 		t.Run(str, func(t *testing.T) {
+			t.Parallel()
+
 			result, err := interpolate.Interpolate(nil, str)
 			if err != nil {
 				t.Fatal(err)
@@ -140,6 +156,8 @@ func TestMissingParameterValuesReturnEmptyStrings(t *testing.T) {
 }
 
 func TestSubstringsWithOffsets(t *testing.T) {
+	t.Parallel()
+
 	environ := interpolate.NewMapEnv(map[string]string{"BUILDKITE_COMMIT": "1adf998e39f647b4b25842f107c6ed9d30a3a7c7"})
 
 	for _, tc := range []struct {
@@ -171,6 +189,8 @@ func TestSubstringsWithOffsets(t *testing.T) {
 		{`${BUILDKITE_COMMIT:7:-128}`, ``},
 	} {
 		t.Run(tc.Str, func(t *testing.T) {
+			t.Parallel()
+
 			result, err := interpolate.Interpolate(environ, tc.Str)
 			if err != nil {
 				t.Fatal(err)
@@ -183,6 +203,8 @@ func TestSubstringsWithOffsets(t *testing.T) {
 }
 
 func TestInterpolateIsntGreedy(t *testing.T) {
+	t.Parallel()
+
 	environ := interpolate.NewMapEnv(map[string]string{
 		"BUILDKITE_COMMIT":       "cfeeee3fa7fa1a6311723f5cbff95b738ec6e683",
 		"BUILDKITE_PARALLEL_JOB": "456",
@@ -207,6 +229,8 @@ func TestInterpolateIsntGreedy(t *testing.T) {
 }
 
 func TestDefaultValues(t *testing.T) {
+	t.Parallel()
+
 	environ := interpolate.NewMapEnv(map[string]string{
 		"DAY":       "Blarghday",
 		"EMPTY_DAY": "",
@@ -236,6 +260,8 @@ func TestDefaultValues(t *testing.T) {
 }
 
 func TestRequiredVariables(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		Str         string
 		ExpectedErr string
@@ -252,6 +278,8 @@ func TestRequiredVariables(t *testing.T) {
 }
 
 func TestEscapingVariables(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		Str      string
 		Expected string
@@ -274,6 +302,8 @@ func TestEscapingVariables(t *testing.T) {
 }
 
 func TestExtractingIdentifiers(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		Str         string
 		Identifiers []string

--- a/interpolate_test.go
+++ b/interpolate_test.go
@@ -260,6 +260,8 @@ func TestEscapingVariables(t *testing.T) {
 		{`Do this \$ESCAPE_PARTY`, `Do this $ESCAPE_PARTY`},
 		{`Do this $${SUCH_ESCAPE}`, `Do this ${SUCH_ESCAPE}`},
 		{`Do this \${SUCH_ESCAPE}`, `Do this ${SUCH_ESCAPE}`},
+		{`Do this $${SUCH_ESCAPE:-$OTHERWISE}`, `Do this ${SUCH_ESCAPE:-$OTHERWISE}`},
+		{`Do this \${SUCH_ESCAPE:-$OTHERWISE}`, `Do this ${SUCH_ESCAPE:-$OTHERWISE}`},
 	} {
 		result, err := interpolate.Interpolate(nil, tc.Str)
 		if err != nil {
@@ -279,11 +281,13 @@ func TestExtractingIdentifiers(t *testing.T) {
 		{`Hello ${REQUIRED_VAR?}`, []string{`REQUIRED_VAR`}},
 		{`${LLAMAS:-${ROCK:-true}}`, []string{`LLAMAS`, `ROCK`}},
 		{`${BUILDKITE_COMMIT:0}`, []string{`BUILDKITE_COMMIT`}},
+		{`$BUILDKITE_COMMIT hello there $$DOUBLE_DOLLAR \$ESCAPED_DOLLAR`, []string{`BUILDKITE_COMMIT`, `$DOUBLE_DOLLAR`, `$ESCAPED_DOLLAR`}},
 	} {
 		id, err := interpolate.Identifiers(tc.Str)
 		if err != nil {
 			t.Fatal(err)
 		}
+
 		if !reflect.DeepEqual(id, tc.Identifiers) {
 			t.Fatalf("Test %q should have identifiers %v, got %v", tc.Str, tc.Identifiers, id)
 		}

--- a/parser_test.go
+++ b/parser_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestParser(t *testing.T) {
+	t.Parallel()
+
 	var testCases = []struct {
 		String   string
 		Expected []interpolate.ExpressionItem
@@ -173,6 +175,8 @@ func TestParser(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.String, func(t *testing.T) {
+			t.Parallel()
+
 			actual, err := interpolate.NewParser(tc.String).Parse()
 			if err != nil {
 				t.Fatal(err)

--- a/parser_test.go
+++ b/parser_test.go
@@ -73,8 +73,7 @@ func TestParser(t *testing.T) {
 		{
 			String: `\${HELLO_WORLD-blah}`,
 			Expected: []interpolate.ExpressionItem{
-				{Text: `$`},
-				{Text: `{HELLO_WORLD-blah}`},
+				{Expansion: interpolate.EscapedExpansion{Identifier: "{HELLO_WORLD-blah}"}},
 			},
 		},
 		{
@@ -82,8 +81,7 @@ func TestParser(t *testing.T) {
 			Expected: []interpolate.ExpressionItem{
 				{Text: `Test `},
 				{Text: `\\`},
-				{Text: `$`},
-				{Text: `{HELLO_WORLD-blah}`},
+				{Expansion: interpolate.EscapedExpansion{Identifier: "{HELLO_WORLD-blah}"}},
 			},
 		},
 		{
@@ -166,6 +164,10 @@ func TestParser(t *testing.T) {
 				{Text: `$(`},
 				{Text: `echo hello world)`},
 			},
+		},
+		{
+			String:   "$$MOUNTAIN",
+			Expected: []interpolate.ExpressionItem{{Expansion: interpolate.EscapedExpansion{Identifier: "MOUNTAIN"}}},
 		},
 	}
 


### PR DESCRIPTION
It's useful for consumers of this libary to be able to know if their input contains things that would be interpolated, and if so, which things. Currently, this is handled by the `interpolate.Identifiers()` function, which returns a list of the interpolate-able identifiers that `interpolate.Interpolate()` would replace.

However, this library makes one further modification to its input: when escaped expansions are included (ie, `$$MY_VAR` or `\$MY_VAR`), they're de-escaped in the output. This is working as intended, but the `interpolate.Identifiers` function doesn't include these escaped interpolations, which is a bit confusing when you're using the `Identifiers` function to determine "will running Interpolate() change the input?"

To remedy this, this PR updates the parse to handle escaped interpolations a bit differently, and treat them as a kind of expansion that doesn't take any input, and de-escapes its input. There's no functionality change, but escaped interpolations now show up in the `Identifiers()` function

This PR also does a little bit of housekeeping - adding a buildkite pipeline, specifying the go version in the go.mod file, etc. Once it's merged, i'll make a release so that we can version this using go modules.