### PR TITLE
Empty escaped interpolations should just be text, not interpolations

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -174,9 +174,13 @@ func TestParser(t *testing.T) {
 		{
 			String: "this is a regex! /^start.*end$$/", // the dollar sign at the end of the regex has to be escaped to be treated as a literal dollar sign by this library
 			Expected: []interpolate.ExpressionItem{
-				{Text: "this is a regex! /^start.*end"},
-				{Expansion: interpolate.EscapedExpansion{Identifier: ""}},
-				{Text: "/"},
+				{Text: "this is a regex! /^start.*end"}, {Text: "$"}, {Text: "/"},
+			},
+		},
+		{
+			String: `this is a more different regex! /^start.*end\$/`, // the dollar sign at the end of the regex has to be escaped to be treated as a literal dollar sign by this library
+			Expected: []interpolate.ExpressionItem{
+				{Text: "this is a more different regex! /^start.*end"}, {Text: "$"}, {Text: "/"},
 			},
 		},
 	}


### PR DESCRIPTION
In #10 and #12, we made it so that escaped interpolations will show up in lists of identifiers to interpolate, largely so that we could [prevent the agent from statically signing steps with interpolations](https://github.com/buildkite/agent/pull/2807).

This approach was somewhat naïve, and assumed that any set of double dollar signs was an escaped interpolation, which [caused the parser to crash](https://github.com/buildkite/agent/pull/2812) whenever there was an escaped dollar sign followed by something that wasn't a variable identifier - eg, having `$$SOMETHING` in your text would be fine, but `$$/` would cause the parser to crash.

this behaviour was fixed in #12, but was still limited, as there were escaped dollar signs that were being treated as interpolations, which isn't necessarily the case - eg, i could have a regex containing an escaped dollar sign: `/hello-.*$$/`, but that's not really an "interpolation", it's just escaped text.

This PR makes it so that if an escaped dollar sign is followed by anything other than a valid variable identifier or a set of braces, it will just be treated as raw text.