### PR TITLE
Fix nested escaped dollarsigns

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/buildkite/interpolate
 
 go 1.22
+
+require github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/interpolate_test.go
+++ b/interpolate_test.go
@@ -281,25 +281,52 @@ func TestEscapingVariables(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
-		Str      string
-		Expected string
+		input string
+		want  string
 	}{
-		{`Do this $$ESCAPE_PARTY`, `Do this $ESCAPE_PARTY`},
-		{`Do this \$ESCAPE_PARTY`, `Do this $ESCAPE_PARTY`},
-		{`Do this $${SUCH_ESCAPE}`, `Do this ${SUCH_ESCAPE}`},
-		{`Do this \${SUCH_ESCAPE}`, `Do this ${SUCH_ESCAPE}`},
-		{`Do this $${SUCH_ESCAPE:-$OTHERWISE}`, `Do this ${SUCH_ESCAPE:-$OTHERWISE}`},
-		{`Do this \${SUCH_ESCAPE:-$OTHERWISE}`, `Do this ${SUCH_ESCAPE:-$OTHERWISE}`},
-		{`Do this $${SUCH_ESCAPE:-$$OTHERWISE}`, `Do this ${SUCH_ESCAPE:-$OTHERWISE}`},
-		{`Do this \${SUCH_ESCAPE:-\$OTHERWISE}`, `Do this ${SUCH_ESCAPE:-$OTHERWISE}`},
-		{`echo "my favourite mountain is cotopaxi" | grep 'xi$$'`, `echo "my favourite mountain is cotopaxi" | grep 'xi$'`},
+		{
+			input: "Do this $$ESCAPE_PARTY",
+			want:  "Do this $ESCAPE_PARTY",
+		},
+		{
+			input: `Do this \$ESCAPE_PARTY`,
+			want:  "Do this $ESCAPE_PARTY",
+		},
+		{
+			input: "Do this $${SUCH_ESCAPE}",
+			want:  "Do this ${SUCH_ESCAPE}",
+		},
+		{
+			input: `Do this \${SUCH_ESCAPE}`,
+			want:  "Do this ${SUCH_ESCAPE}",
+		},
+		{
+			input: "Do this $${SUCH_ESCAPE:-$OTHERWISE}",
+			want:  "Do this ${SUCH_ESCAPE:-}",
+		},
+		{
+			input: `Do this \${SUCH_ESCAPE:-$OTHERWISE}`,
+			want:  "Do this ${SUCH_ESCAPE:-}",
+		},
+		{
+			input: "Do this $${SUCH_ESCAPE:-$$OTHERWISE}",
+			want:  "Do this ${SUCH_ESCAPE:-$OTHERWISE}",
+		},
+		{
+			input: `Do this \${SUCH_ESCAPE:-\$OTHERWISE}`,
+			want:  "Do this ${SUCH_ESCAPE:-$OTHERWISE}",
+		},
+		{
+			input: `echo "my favourite mountain is cotopaxi" | grep 'xi$$'`,
+			want:  `echo "my favourite mountain is cotopaxi" | grep 'xi$'`,
+		},
 	} {
-		result, err := interpolate.Interpolate(nil, tc.Str)
+		result, err := interpolate.Interpolate(nil, tc.input)
 		if err != nil {
-			t.Fatal(err)
+			t.Errorf("interpolate.Interpolate(nil, %q) error = %v", tc.input, err)
 		}
-		if result != tc.Expected {
-			t.Fatalf("Test %q failed: Expected substring %q, got %q", tc.Str, tc.Expected, result)
+		if result != tc.want {
+			t.Errorf("interpolate.Interpolate(nil, %q) = %q, want %q", tc.input, tc.want, result)
 		}
 	}
 }

--- a/interpolate_test.go
+++ b/interpolate_test.go
@@ -290,6 +290,8 @@ func TestEscapingVariables(t *testing.T) {
 		{`Do this \${SUCH_ESCAPE}`, `Do this ${SUCH_ESCAPE}`},
 		{`Do this $${SUCH_ESCAPE:-$OTHERWISE}`, `Do this ${SUCH_ESCAPE:-$OTHERWISE}`},
 		{`Do this \${SUCH_ESCAPE:-$OTHERWISE}`, `Do this ${SUCH_ESCAPE:-$OTHERWISE}`},
+		{`Do this $${SUCH_ESCAPE:-$$OTHERWISE}`, `Do this ${SUCH_ESCAPE:-$OTHERWISE}`},
+		{`Do this \${SUCH_ESCAPE:-\$OTHERWISE}`, `Do this ${SUCH_ESCAPE:-$OTHERWISE}`},
 		{`echo "my favourite mountain is cotopaxi" | grep 'xi$$'`, `echo "my favourite mountain is cotopaxi" | grep 'xi$'`},
 	} {
 		result, err := interpolate.Interpolate(nil, tc.Str)

--- a/parser.go
+++ b/parser.go
@@ -87,7 +87,7 @@ func (p *Parser) parseExpression(stop ...rune) (Expression, error) {
 				return nil, err
 			}
 
-			expr = append(expr, ee)
+			expr = append(expr, ExpressionItem{Expansion: ee})
 			continue
 		}
 
@@ -122,28 +122,39 @@ func (p *Parser) parseExpression(stop ...rune) (Expression, error) {
 	return expr, nil
 }
 
-func (p *Parser) parseEscapedExpansion() (ExpressionItem, error) {
+// parseEscapedExpansion attempts to extract a *potential* identifier or brace
+// expression from the text following the escaped dollarsign.
+func (p *Parser) parseEscapedExpansion() (EscapedExpansion, error) {
+	// Since it's not an expansion, we should treat the following text as text.
+	start := p.pos
+	defer func() { p.pos = start }()
+
 	next := p.peekRune()
 	switch {
 	case next == '{':
-		// if it's an escaped brace expansion, (eg $${MY_COOL_VAR:-5}) consume text until the close brace
-		id := p.scanUntil(func(r rune) bool { return r == '}' })
-		id = id + string(p.nextRune()) // we know that the next rune is a close brace, chuck it on the end
-		return ExpressionItem{Expansion: EscapedExpansion{Identifier: id}}, nil
+		// it *could be* an escaped brace expansion
+		if _, err := p.parseBraceExpansion(); err != nil {
+			return EscapedExpansion{}, nil
+		}
+		// it was! instead of storing the expansion itself, store the string
+		// that produced it.
+		return EscapedExpansion{PotentialIdentifier: p.input[start:p.pos]}, nil
 
 	case unicode.IsLetter(next):
-		// it's an escaped identifier (eg $$MY_COOL_VAR)
+		// it *could be* an escaped identifier (eg $$MY_COOL_VAR)
 		id, err := p.scanIdentifier()
 		if err != nil {
-			return ExpressionItem{}, err
+			// this should never happen, since scanIdentifier only errors if the
+			// first rune is not a letter, and we just checked that.
+			return EscapedExpansion{}, nil
 		}
 
-		return ExpressionItem{Expansion: EscapedExpansion{Identifier: id}}, nil
+		return EscapedExpansion{PotentialIdentifier: id}, nil
 
 	default:
-		// there's no identifier or brace afterward, so it's probably a literal escaped dollar sign
-		// just return a text item with the dollar sign
-		return ExpressionItem{Text: "$"}, nil
+		// there's no identifier or brace afterward, so it's probably a literal
+		// escaped dollar sign
+		return EscapedExpansion{}, nil
 	}
 }
 
@@ -162,7 +173,9 @@ func (p *Parser) parseExpansion() (Expansion, error) {
 		return nil, err
 	}
 
-	return VariableExpansion{Identifier: identifier}, nil
+	return VariableExpansion{
+		Identifier: identifier,
+	}, nil
 }
 
 func (p *Parser) parseBraceExpansion() (Expansion, error) {
@@ -177,7 +190,9 @@ func (p *Parser) parseBraceExpansion() (Expansion, error) {
 
 	if c := p.peekRune(); c == '}' {
 		_ = p.nextRune()
-		return VariableExpansion{Identifier: identifier}, nil
+		return VariableExpansion{
+			Identifier: identifier,
+		}, nil
 	}
 
 	var operator string
@@ -298,8 +313,8 @@ func (p *Parser) scanIdentifier() (string, error) {
 	if c := p.peekRune(); !unicode.IsLetter(c) {
 		return "", fmt.Errorf("Expected identifier to start with a letter, got %c", c)
 	}
-	var notIdentifierChar = func(r rune) bool {
-		return (!unicode.IsLetter(r) && !unicode.IsNumber(r) && r != '_')
+	notIdentifierChar := func(r rune) bool {
+		return !(unicode.IsLetter(r) || unicode.IsNumber(r) || r == '_')
 	}
 	return p.scanUntil(notIdentifierChar), nil
 }


### PR DESCRIPTION
### What
Change how escaped expansions work back to only "expanding" to a `$` - but still capture the potential identifier or brace expression that follows.

Given `BAR=bar`, `$${FOO:$BAR}` expands to `${FOO:bar}` and `$${FOO:$$BAR}` expands to `${FOO:$BAR}` (the pre-#10) behaviour).

While I'm here, do a bunch of work on the tests.

### Why
Fixes #14 

### How
Originally, `\$` and `$$` were parsed into a single `$` as plain text, and it didn't affect the interpretation of the following text. 

We had the need to find potential "run-time" interpolations in buildkite-agent, so "escaped expansions" were added that parse like "normal" variable expansions, but produce different text when expanded. `EscapedExpansion` then had to be _expanded_ (ahem) to handle brace expressions as well.

Here are the key changes in this PR:

```diff
 func (e EscapedExpansion) Expand(Env) (string, error) {
-       return "$" + e.Identifier, nil
+       return "$", nil
 }
```

and [here](https://github.com/buildkite/interpolate/blob/fbdc2db03b80a0b99d1191a87f351b25768e91a0/parser.go#L125-L159).

Previously, `EscapedExpansion` would capture the identifier or brace expression that followed it. This caused problems for the interpretation of nested expansions: if the escaped dollarsign were treated simply as text as it should be, then expressions nested within the brace following the escaped dollarsign could be parsed and expanded as intended. Instead, because the brace was captured by `EscapedExpansion`, and expanded verbatim, that wouldn't happen.

Now, `EscapedExpansion` goes back to expanding only to `$`. Instead of capturing the following identifier or brace for expansion, it records what it was, then the parser restarts from the same position as text.