### PR TITLE
Treat bare dollar sign as literal and dont interpolate

### DIFF
--- a/interpolate_test.go
+++ b/interpolate_test.go
@@ -114,22 +114,6 @@ func TestIgnoresParentheses(t *testing.T) {
 	}
 }
 
-func TestVariablesMustStartWithLetters(t *testing.T) {
-	t.Parallel()
-
-	for _, str := range []string{
-		`$1 burgers`,
-		`$99bottles`,
-	} {
-		_, err := interpolate.Interpolate(nil, str)
-		if err == nil {
-			t.Fatalf("Test %q should have resulted in an error", str)
-		} else {
-			t.Log(err)
-		}
-	}
-}
-
 func TestMissingParameterValuesReturnEmptyStrings(t *testing.T) {
 	t.Parallel()
 

--- a/interpolate_test.go
+++ b/interpolate_test.go
@@ -342,6 +342,7 @@ func TestExtractingIdentifiers(t *testing.T) {
 		{`${LLAMAS:-${ROCK:-true}}`, []string{`LLAMAS`, `ROCK`}},
 		{`${BUILDKITE_COMMIT:0}`, []string{`BUILDKITE_COMMIT`}},
 		{`$BUILDKITE_COMMIT hello there $$DOUBLE_DOLLAR \$ESCAPED_DOLLAR`, []string{`BUILDKITE_COMMIT`, `$DOUBLE_DOLLAR`, `$ESCAPED_DOLLAR`}},
+		{`This $ is not a variable`, []string{}},
 	} {
 		id, err := interpolate.Identifiers(tc.Str)
 		if err != nil {

--- a/parser.go
+++ b/parser.go
@@ -178,7 +178,7 @@ func (p *Parser) parseExpansion() (ExpressionItem, error) {
 	}
 
 	// if not a letter, it's a literal dollar sign
-	if !unicode.IsLetter(c) && !unicode.IsNumber(c) {
+	if !unicode.IsLetter(c) {
 		return ExpressionItem{Text: "$"}, nil
 	}
 

--- a/parser.go
+++ b/parser.go
@@ -98,6 +98,13 @@ func (p *Parser) parseExpression(stop ...rune) (Expression, error) {
 			continue
 		}
 
+		// Ignore empty variable references
+		if strings.HasPrefix(p.input[p.pos:], `$ `) {
+			p.pos += 2
+			expr = append(expr, ExpressionItem{Text: `$ `})
+			continue
+		}
+
 		// If we run into a dollar sign and it's not the last char, it's an expansion
 		if c == '$' && p.pos < (len(p.input)-1) {
 			expansion, err := p.parseExpansion()


### PR DESCRIPTION
1. Treat bare `$` as literal and don't raise an error trying and failing to interpolate it
2. Treat identifiers (`$<IDENTIFIER>`) not starting with a letter or brace as literal and don't raise error.